### PR TITLE
only add controller_additions if controller responds to helper method #12

### DIFF
--- a/lib/action_access/controller_additions.rb
+++ b/lib/action_access/controller_additions.rb
@@ -48,7 +48,7 @@ module ActionAccess
 
     def self.included(base)
       base.extend ClassMethods
-      base.helper_method :keeper
+      base.helper_method :keeper if base.respond_to? :helper_method
     end
 
 


### PR DESCRIPTION
This Pull requests add graceful handling to the controller additions in case the requested controller does not support `"helper_method`
Please let me know for any needed changes.

Thanks
jan