### PR TITLE
Support use in Rails 5 ActionController::API

### DIFF
--- a/lib/action_access/controller_additions.rb
+++ b/lib/action_access/controller_additions.rb
@@ -48,7 +48,7 @@ module ActionAccess
 
     def self.included(base)
       base.extend ClassMethods
-      base.helper_method :keeper
+      base.helper_method(:keeper) if base.respond_to?(:helper_method)
     end
 
 


### PR DESCRIPTION
Prevents the following error from occurring:

```
NoMethodError: undefined method `helper_method' for ActionController::API:Class
```

See matiasgagliano/action_access#12